### PR TITLE
Patch v1.2.1: remove print and update rerun() to non-experiment

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     install_requires=[
         "boto3 >= 1.26.52",
         "pycognito >= 2022.12.0",
-        "streamlit >= 1.17.0",
+        "streamlit >= 1.27.0",
         "extra_streamlit_components >= 0.1.56",
     ],
     author="Sarawin Khemmachotikun",

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="streamlit-cognito-auth",
-    version="1.2.0",
+    version="1.2.1",
     packages=find_packages("src"),
     package_dir={"": "src"},
     include_package_data=True,

--- a/src/streamlit_cognito_auth/auth.py
+++ b/src/streamlit_cognito_auth/auth.py
@@ -255,7 +255,7 @@ class CognitoAuthenticator:
 
             status_container.success("Logged in")
             time.sleep(1.5)
-            st.experimental_rerun()
+            st.rerun()
 
         # login
         login_submitted, username, password, status_container = self._show_login_form(
@@ -273,7 +273,7 @@ class CognitoAuthenticator:
             if st.session_state["auth_reset_password_session"]:
                 status_container.info("Password reset is required")
                 time.sleep(1.5)
-                st.experimental_rerun()
+                st.rerun()
 
             if not is_logged_in:
                 status_container.error("Invalid username or password")
@@ -281,12 +281,12 @@ class CognitoAuthenticator:
 
             status_container.success("Logged in")
             time.sleep(1.5)
-            st.experimental_rerun()
+            st.rerun()
 
         except Exception as e:
             status_container.error(f"Unknown error {e}")
             time.sleep(1.5)
-            st.experimental_rerun()
+            st.rerun()
 
         # should not reach here
         # prevent other code from running

--- a/src/streamlit_cognito_auth/utils.py
+++ b/src/streamlit_cognito_auth/utils.py
@@ -13,5 +13,4 @@ def verify_access_token(pool_id, app_client_id, region, token):
         claims = u.verify_token(token, "access_token", "access")
         return claims
     except pycognito.exceptions.TokenVerificationException as e:
-        print("error")
         raise TokenVerificationException(e)


### PR DESCRIPTION
st.rerun() is not experimental anymore and the experimental version get deprecated in April;
Due to mess from v1.3.0 I still use v1.2 and I patch it with this.
Also remove useless print for better logs

This MR has to be compared to tag v1.2.0 but has it doesn't have its own branche, I can't do it :)