### PR TITLE
Method for retrieving UserInfo using the Authenticator

### DIFF
--- a/src/streamlit_cognito_auth/auth.py
+++ b/src/streamlit_cognito_auth/auth.py
@@ -343,27 +343,20 @@ class CognitoAuthenticatorBase(ABC):
         Returns:
             dict | None: The response from the UserInfo endpoint. Returns None if the Authenticator has not been assigned the 'domain' attribute.
         """
-
-        # Retrieve the cognito domain if it exists in self
         if hasattr(self, "domain"):
             userinfo_url = f"{self.domain}/oauth2/userInfo"
             headers = {
                 "Content-Type": "application/json;charset=UTF-8",
                 "Authorization": f"Bearer {self.get_credentials().access_token}",
             }
-
             resp = requests.get(userinfo_url, headers=headers)
-
             if include:
                 filtered = {k: v for k, v in resp.json().items() if k in include}
                 return filtered
-
             return resp.json()
-
         else:
             logging.warning("Instantiated Authenticator has not been assigned the 'domain' attribute")
             return None
-
 
 
 class CognitoAuthenticator(CognitoAuthenticatorBase):


### PR DESCRIPTION
I needed to display some simple user information,  and thought it was cleaner to implement it directly in the CognitoAuthenticatorBase class rather than creating a separate function for it. 

Currently works for CognitoHostedUIAuthenticator because that class has the cognito domain attribute. I cant implement the same for CognitoAuthenticator because I am constrained to using Cognito Hosted UI. 

A simple implementation of the method would be like this:
```
# For hosted UI
authenticator = CognitoHostedUIAuthenticator(...)
user_info = authenticator.get_user_info()
st.write(user_info)
```

So far I havent thought of any way to retrieve the UserInfo or cognito domain using the attributes available in the CognitoAuthenticator. One hacky workaround is simply assigning the attribute after the class is instantiated:
```
# For regular authenticator
authenticator = CognitoAuthenticator(...)
authenticator.domain = "https://<domain>.auth.<region>.amazoncognito.com" # Assign domain to existing instance
user_info = authenticator.get_user_info()
st.write(user_info)
```