### PR TITLE
Add support for authentication Software MFA token

### DIFF
--- a/examples/example.py
+++ b/examples/example.py
@@ -11,7 +11,8 @@ authenticator = CognitoAuthenticator(
     pool_id=pool_id,
     app_client_id=app_client_id,
     app_client_secret=app_client_secret,
-    use_cookies=False
+    use_cookies=False,
+    app_name="StreamlitAuthTest"
 )
 
 is_logged_in = authenticator.login()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "requests >= 2.31.0",
     "streamlit >= 1.27.0",
     "extra_streamlit_components >= 0.1.71",
+    "qrcode"
 ]
 readme = "README.md"
 requires-python = ">= 3.8"


### PR DESCRIPTION
I have added support for authentication with Software MFA apps (not tested with SMS) when MFA is enforced in cognito and it will not break the functionality for the ones not enforced.

Pls review and share feedback, let me know if I need to make a video for showing it works.